### PR TITLE
Fix test imports by adding backend path to PYTHONPATH

### DIFF
--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,0 +1,6 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))


### PR DESCRIPTION
## Summary
- ensure pytest automatically adds the backend project root to `sys.path`
- allow tests to import the `app` package without depending on execution context

## Testing
- `poetry -C backend run pytest` *(fails: missing dependencies in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e185281d688323b584d21cb96d7482