### PR TITLE
Fix FastAPI router import to prevent AttributeError

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,7 +1,7 @@
 from fastapi import FastAPI, Depends
 from fastapi.middleware.cors import CORSMiddleware
 
-from app.api import router as api_router
+from app.api.router import router as api_router
 from app.core.config import get_settings
 
 


### PR DESCRIPTION
## Summary
- import the API router object directly in `create_app` so FastAPI can include routes without raising an AttributeError

## Testing
- poetry -C backend run pytest *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68e186a62d78832383e339081c26aad5