### PR TITLE
Filter prior Nobel laureates from predictions

### DIFF
--- a/backend/app/data/seed/physics_candidates.json
+++ b/backend/app/data/seed/physics_candidates.json
@@ -38,6 +38,7 @@
     "affiliation": "Nagoya University",
     "country": "Japan",
     "headshot_url": "https://example.com/hirosi_amano.jpg",
+    "is_laureate": true,
     "features": {
       "as_of_year": 2024,
       "total_citations": 28000,

--- a/backend/app/flows/etl.py
+++ b/backend/app/flows/etl.py
@@ -38,6 +38,7 @@ def upsert_candidates(records: List[dict]) -> None:
                     affiliation=record["affiliation"],
                     country=record.get("country"),
                     headshot_url=record.get("headshot_url"),
+                    is_laureate=record.get("is_laureate", False),
                 )
                 session.add(candidate)
                 session.flush()
@@ -47,6 +48,7 @@ def upsert_candidates(records: List[dict]) -> None:
                 candidate.affiliation = record["affiliation"]
                 candidate.country = record.get("country")
                 candidate.headshot_url = record.get("headshot_url")
+                candidate.is_laureate = record.get("is_laureate", False)
 
             features = record["features"]
             snapshot = (
@@ -72,6 +74,7 @@ def persist_feature_table(records: List[dict], output_path: Path) -> Path:
         entry = {
             "openalex_id": record["openalex_id"],
             "field": record["field"],
+            "is_laureate": record.get("is_laureate", False),
             **record["features"],
         }
         rows.append(entry)

--- a/backend/app/flows/modeling.py
+++ b/backend/app/flows/modeling.py
@@ -95,6 +95,8 @@ def persist_predictions(predictions: List[dict]) -> None:
             candidate = candidate_map.get(record["openalex_id"])
             if candidate is None:
                 continue
+            if candidate.is_laureate:
+                continue
             prediction = Prediction(
                 candidate_id=candidate.id,
                 year=record["year"],

--- a/backend/app/models/nobel.py
+++ b/backend/app/models/nobel.py
@@ -1,6 +1,6 @@
 from datetime import date
 
-from sqlalchemy import Column, Date, Float, ForeignKey, Integer, String
+from sqlalchemy import Boolean, Column, Date, Float, ForeignKey, Integer, String
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from app.models.base import Base
@@ -16,6 +16,7 @@ class Candidate(Base):
     affiliation: Mapped[str] = mapped_column(String, nullable=False)
     country: Mapped[str] = mapped_column(String, nullable=True)
     headshot_url: Mapped[str] = mapped_column(String, nullable=True)
+    is_laureate: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
 
     feature_snapshots: Mapped[list["FeatureSnapshot"]] = relationship(back_populates="candidate")
     predictions: Mapped[list["Prediction"]] = relationship(back_populates="candidate")

--- a/backend/app/services/bootstrap.py
+++ b/backend/app/services/bootstrap.py
@@ -1,6 +1,8 @@
 import shutil
 from pathlib import Path
 
+from sqlalchemy import inspect
+
 from app.core.config import get_settings
 from app.core.database import engine
 from app.models.base import Base
@@ -10,6 +12,11 @@ settings = get_settings()
 
 
 def bootstrap_state() -> None:
+    inspector = inspect(engine)
+    if inspector.has_table("candidates"):
+        columns = {column["name"] for column in inspector.get_columns("candidates")}
+        if "is_laureate" not in columns:
+            Base.metadata.drop_all(bind=engine)
     Base.metadata.create_all(bind=engine)
     seed_source = Path(__file__).resolve().parents[1] / "data" / "seed"
     seed_target = settings.data_dir / "seed"

--- a/backend/app/services/prediction_service.py
+++ b/backend/app/services/prediction_service.py
@@ -25,7 +25,11 @@ class PredictionService:
             query = (
                 session.query(Prediction, Candidate)
                 .join(Candidate, Candidate.id == Prediction.candidate_id)
-                .filter(Candidate.field == field, Prediction.horizon == horizon)
+                .filter(
+                    Candidate.field == field,
+                    Candidate.is_laureate.is_(False),
+                    Prediction.horizon == horizon,
+                )
                 .order_by(Prediction.probability.desc())
                 .limit(20)
             )

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -39,6 +39,16 @@ def test_shortlist_endpoint(field):
     assert payload[0]["candidate_name"]
 
 
+def test_shortlist_excludes_laureates():
+    response = client.get(
+        "/api/v1/predictions/shortlist", params={"field": "Physics", "horizon": "one_year"}
+    )
+    assert response.status_code == 200
+    payload = response.json()
+    laureates = [entry for entry in payload if entry["candidate_name"] == "Hiroshi Amano"]
+    assert not laureates
+
+
 def test_reports_generation(tmp_path):
     response = client.get("/api/v1/reports/shortlist.csv", params={"field": "Physics", "horizon": "one_year"})
     assert response.status_code == 200


### PR DESCRIPTION
## Summary
- add an `is_laureate` flag to candidates and exclude Nobel laureates from training outputs and shortlist queries
- mark Hiroshi Amano as a laureate in the physics seed data and rebuild tables when the schema is missing the new column
- extend the API tests to ensure Nobel laureates never appear in the shortlist

## Testing
- `poetry run pytest` *(fails: No module named 'packaging.licenses')*

------
https://chatgpt.com/codex/tasks/task_e_68e1f08d21208323ad4bb1bb6743d92c