### PR TITLE
Bootstrap prediction seeds during startup

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,8 +1,9 @@
-from fastapi import FastAPI, Depends
+from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
 from app.api.router import router as api_router
 from app.core.config import get_settings
+from app.services.bootstrap import bootstrap_state
 
 
 def create_app() -> FastAPI:
@@ -23,6 +24,11 @@ def create_app() -> FastAPI:
 
 
 app = create_app()
+
+
+@app.on_event("startup")
+def on_startup() -> None:
+    bootstrap_state()
 
 
 @app.get("/health", tags=["system"])

--- a/backend/app/services/prediction_service.py
+++ b/backend/app/services/prediction_service.py
@@ -1,8 +1,10 @@
-from datetime import datetime
 import json
+from datetime import datetime
 from typing import List
 
 import pandas as pd
+
+from fastapi import HTTPException, status
 
 from app.core.config import get_settings
 from app.core.database import db_session
@@ -87,6 +89,11 @@ class PredictionService:
 
     def get_backtests(self, field: str | None) -> List[BacktestMetricSchema]:
         backtests_path = settings.data_dir / "seed" / "backtests.json"
+        if not backtests_path.exists():
+            raise HTTPException(
+                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                detail="Backtest metrics are not available yet.",
+            )
         df = pd.read_json(backtests_path)
         if field:
             df = df[df["field"] == field]


### PR DESCRIPTION
## Summary
- call the bootstrap routine when the FastAPI app starts so seed data is available before requests
- add a guard in the prediction service to surface an HTTP 503 when backtest metrics are missing
- update the API integration tests to rely on startup bootstrapping and verify the backtests endpoint

## Testing
- `poetry run pytest` *(fails: No module named 'packaging.licenses')*

------
https://chatgpt.com/codex/tasks/task_e_68e2ba575b7483238b3aa8f892c3310e