### PR TITLE
Define response schema for training endpoint

### DIFF
--- a/backend/app/api/v1/training.py
+++ b/backend/app/api/v1/training.py
@@ -1,9 +1,22 @@
+from typing import Dict, TypedDict
+
 from fastapi import APIRouter
 
 from app.services.training_service import TrainingService
 
 router = APIRouter()
 service = TrainingService()
+
+
+class ModelTrainingDetails(TypedDict):
+    model_paths: Dict[str, str]
+    prediction_count: int
+    run_id: str
+
+
+class TrainModelResponse(TypedDict):
+    status: str
+    details: ModelTrainingDetails
 
 
 @router.post("/etl")
@@ -13,6 +26,6 @@ def run_etl() -> dict[str, str]:
 
 
 @router.post("/model")
-def train_model() -> dict[str, str]:
+def train_model() -> TrainModelResponse:
     model_info = service.train_models()
     return {"status": "trained", "details": model_info}

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -64,3 +64,16 @@ def test_backtests_bootstrapped(client: TestClient):
     payload = response.json()
     assert isinstance(payload, list)
     assert payload
+
+
+def test_train_model_endpoint(client: TestClient):
+    response = client.post("/api/v1/training/model")
+    assert response.status_code == 200
+
+    payload = response.json()
+    assert payload["status"] == "trained"
+    details = payload["details"]
+    assert set(details.keys()) == {"model_paths", "prediction_count", "run_id"}
+    assert isinstance(details["model_paths"], dict)
+    assert isinstance(details["prediction_count"], int)
+    assert isinstance(details["run_id"], str)


### PR DESCRIPTION
## Summary
- define TypedDict-based response schema for the training endpoint to reflect the returned payload
- ensure the endpoint uses the schema while keeping the Prefect flow details intact
- extend API tests to cover the training endpoint response structure

## Testing
- pytest backend/tests/test_api.py *(fails: FastAPI/Pydantic import error due to ForwardRef recursion guard on Python 3.12 environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e2eb9f3d488323889b1915d158ffab