### PR TITLE
Ensure backend Docker image includes sitecustomize module

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -13,6 +13,7 @@ RUN pip install --no-cache-dir poetry && poetry config virtualenvs.create false 
     && poetry install --without dev --no-root
 # (Equivalent alternative:  poetry install --only main --no-root)
 
+COPY sitecustomize.py ./
 COPY app ./app
 COPY storage ./storage
 COPY app/data ./app/data


### PR DESCRIPTION
## Summary
- copy the runtime compatibility shim into the backend Docker image so FastAPI can import `sitecustomize`

## Testing
- not run (dependency installation failed: `No module named 'packaging.licenses'`)


------
https://chatgpt.com/codex/tasks/task_e_68e331e928c88323a6e46baa7eb3148f