### PR TITLE
Document manual bootstrap commands for Windows users

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ A production-ready skeleton that demonstrates how to ingest bibliometric seed da
 - Python 3.11
 - Node.js 18+
 - Docker (optional but recommended)
+- GNU Make (installed by default on macOS/Linux; Windows users can install it via [Chocolatey](https://community.chocolatey.org/packages/make) or WSL, or follow the manual steps below.)
 
 ### Local bootstrap
 
@@ -29,6 +30,21 @@ make bootstrap
 ```
 
 This installs dependencies, boots the SQLite schema, runs the seed ETL, trains the baseline model, and saves predictions/reports into `storage/`.
+
+#### Windows without `make`
+
+If `make` is unavailable in PowerShell or Command Prompt, run the underlying commands manually from the repository root:
+
+```powershell
+cd backend
+poetry install
+poetry run python -c "from app.services.bootstrap import bootstrap_state; bootstrap_state()"
+poetry run python -c "from app.services.training_service import TrainingService; s=TrainingService(); s.run_etl(); s.train_models()"
+cd ..\frontend
+npm install
+```
+
+This sequence mirrors the `make bootstrap` target so you can rebuild `storage/nobel.db` and the cached artifacts without requiring GNU Make.
 
 ### Running the stack locally
 


### PR DESCRIPTION
## Summary
- note that GNU Make is required and provide installation guidance for Windows users
- document the manual bootstrap commands so Windows shells without `make` can rebuild the database

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e3348484fc8323881f6f43b132e93b